### PR TITLE
Convert linestrings within to strtree for 100x speed up

### DIFF
--- a/changelog.d/44.feature.md
+++ b/changelog.d/44.feature.md
@@ -1,0 +1,1 @@
+Convert the centerline within check to use Shapely STRTrees

--- a/src/centerline/geometry.py
+++ b/src/centerline/geometry.py
@@ -87,7 +87,7 @@ class Centerline:
 
         str_tree = STRtree(linestrings)
         linestrings_indexes = str_tree.query(self._input_geometry, 'contains')
-        contained_linestrings = [linestrings[i] for i in linestring_indexes]
+        contained_linestrings = [linestrings[i] for i in linestrings_indexes]
         if len(contained_linestrings) < 2:
             raise exceptions.TooFewRidgesError
 

--- a/src/centerline/geometry.py
+++ b/src/centerline/geometry.py
@@ -86,7 +86,7 @@ class Centerline:
                 linestrings.append(linestring)
 
         str_tree = STRtree(linestrings)
-        linestrings_indexes = str_tree.query(self._input_geometry, 'contains')
+        linestrings_indexes = str_tree.query(self._input_geometry, "contains")
         contained_linestrings = [linestrings[i] for i in linestrings_indexes]
         if len(contained_linestrings) < 2:
             raise exceptions.TooFewRidgesError

--- a/src/centerline/geometry.py
+++ b/src/centerline/geometry.py
@@ -86,7 +86,8 @@ class Centerline:
                 linestrings.append(linestring)
 
         str_tree = STRtree(linestrings)
-        contained_linestrings = [linestrings[i] for i in str_tree.query(self._input_geometry, 'contains')]
+        linestrings_indexes = str_tree.query(self._input_geometry, 'contains')
+        contained_linestrings = [linestrings[i] for i in linestring_indexes]
         if len(contained_linestrings) < 2:
             raise exceptions.TooFewRidgesError
 

--- a/src/centerline/geometry.py
+++ b/src/centerline/geometry.py
@@ -6,6 +6,7 @@ from numpy import array
 from scipy.spatial import Voronoi
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon
 from shapely.ops import unary_union
+from shapely.strtree import STRtree
 
 from . import exceptions
 
@@ -82,14 +83,14 @@ class Centerline:
                     x=vertices[ridge[1]][0], y=vertices[ridge[1]][1]
                 )
                 linestring = LineString((starting_point, ending_point))
+                linestrings.append(linestring)
 
-                if self._linestring_is_within_input_geometry(linestring):
-                    linestrings.append(linestring)
-
-        if len(linestrings) < 2:
+        str_tree = STRtree(linestrings)
+        contained_linestrings = [linestrings[i] for i in str_tree.query(self._input_geometry, 'contains')]
+        if len(contained_linestrings) < 2:
             raise exceptions.TooFewRidgesError
 
-        return unary_union(linestrings)
+        return unary_union(contained_linestrings)
 
     def _get_voronoi_vertices_and_ridges(self):
         borders = self._get_densified_borders()


### PR DESCRIPTION
Hello! 

Using centerline for larger more complex polygons took a while, conveting to [STRTree ](https://shapely.readthedocs.io/en/stable/strtree.html)causes a massive speed up. I've used STRTree a few other times and I have never had an issue with different data being outputted. Testing on my current system for centerline, I get the same amount of lines outputted. In my example, it provides an over 100x speed up. In smaller, simple polygons, there is a chance STRTree takes longer than the old system, but it would be extremely minimal. I would say anything over 4-5 within checks and I would expect STRTree to be faster.

Before:
![image](https://github.com/fitodic/centerline/assets/20257911/f6f9504e-c3e9-40d7-a33f-b9600c69310d)
After:
![image](https://github.com/fitodic/centerline/assets/20257911/d20374bf-266d-471c-bdef-a305f1254a6d)
