### PR TITLE
adding predicate to str_tree query

### DIFF
--- a/changelog.d/47.bugfix.rst
+++ b/changelog.d/47.bugfix.rst
@@ -1,0 +1,1 @@
+Adding `predicate` as a named parameter in `str_tree.query`

--- a/src/centerline/geometry.py
+++ b/src/centerline/geometry.py
@@ -86,7 +86,9 @@ class Centerline:
                 linestrings.append(linestring)
 
         str_tree = STRtree(linestrings)
-        linestrings_indexes = str_tree.query(self._input_geometry, predicate="contains")
+        linestrings_indexes = str_tree.query(
+            self._input_geometry, predicate="contains"
+        )
         contained_linestrings = [linestrings[i] for i in linestrings_indexes]
         if len(contained_linestrings) < 2:
             raise exceptions.TooFewRidgesError

--- a/src/centerline/geometry.py
+++ b/src/centerline/geometry.py
@@ -86,7 +86,7 @@ class Centerline:
                 linestrings.append(linestring)
 
         str_tree = STRtree(linestrings)
-        linestrings_indexes = str_tree.query(self._input_geometry, "contains")
+        linestrings_indexes = str_tree.query(self._input_geometry, predicate="contains")
         contained_linestrings = [linestrings[i] for i in linestrings_indexes]
         if len(contained_linestrings) < 2:
             raise exceptions.TooFewRidgesError


### PR DESCRIPTION
Shapely updates require `predicate` as a named parameter in `query`. Making the minor fix to resolve issue #46 and probably what #45 was referencing too. 