### PR TITLE
Fix CenterlineError default message spelling

### DIFF
--- a/changelog.d/54.bugfix.rst
+++ b/changelog.d/54.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed spelling in the default ``CenterlineError`` message.

--- a/src/centerline/exceptions.py
+++ b/src/centerline/exceptions.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 
 class CenterlineError(Exception):
-    default_message = "An error has occured while constucting the centerline."
+    default_message = "An error has occurred while constructing the centerline."
 
     def __init__(self, *args, **kwargs):  # pragma: no cover
         if not (args or kwargs):


### PR DESCRIPTION
## Summary
- Correct the spelling in the default `CenterlineError` message.
- Add the required towncrier bugfix fragment for this PR.

## Validation
- `PYTHONPATH=src python3 - <<'PY' ...` assertion for `str(CenterlineError())`
- `python3 -m py_compile src/centerline/exceptions.py`
- `git diff --check upstream/master...HEAD`

Not run: full `tox`/`pytest` suite because those tools are not installed locally, and the project test environment depends on GDAL.